### PR TITLE
SEA-22: fix top and bottom positioning in menu icon animation

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -36,9 +36,9 @@ export const Nav = ({ setLightTheme, lightTheme }: NavProps): ReactElement => {
         <div className="relative flex items-center justify-between h-16">
           <div className="absolute inset-y-0 left-0 flex items-center sm:hidden text-sea-blue-300 hover:text-sea-blue-900 dark:text-sea-white-400 dark:hover:text-sea-white-100">
             <a href='#' className="h-8 w-8 flex items-center" onClick={() => setMobileMenu(!mobileMenu)}>
-              <span className={classNames([ mobileMenu ? 'h-0 after:rotate-45 after:top-0 before:-bottom-0.5 before:-rotate-45' : 'h-0.5', 'bg-white rounded-full w-full absolute transition-all duration-100',
-                'after:bg-white after:rounded-full after:h-0.5 after:w-full after:absolute after:transition-all after:duration-100 after:-top-2',
-                'before:bg-white before:rounded-full before:h-0.5 before:w-full before:absolute before:-bottom-2' ])}></span>
+              <span className={classNames([ mobileMenu ? 'h-0 after:rotate-45 after:top-0 before:-bottom-0.5 before:-rotate-45' : 'h-0.5 after:-top-2 before:-bottom-2', 'bg-white rounded-full w-full absolute transition-all duration-100',
+                'after:bg-white after:rounded-full after:h-0.5 after:w-full after:absolute after:transition-all after:duration-100',
+                'before:bg-white before:rounded-full before:h-0.5 before:w-full before:absolute' ])}></span>
             </a>
           </div>
           <div className="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a bug in the animation where the top and bottom positioning were competing with ones that were still applied to the class.  This now swaps them out instead of having both of them when applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.