### PR TITLE
SEA-27: add desktop nav cypress tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: 🧪 Cypress Tests
         uses: cypress-io/github-action@v4
         with:
-          start: npm run test:cypress
+          start: npm run test:ci:cypress
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
           browser: chrome

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ If it is your first time using Cypress on your machine you will need to install 
 npx cypress open
 ```
 
+Start the project so that Cypress can access the running page:
+```bash
+npm run dev
+```
+
 From here you can run the tests in headless mode using the command:
 ```bash
 npm run test:cypress

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -28,7 +28,10 @@ export const Nav = ({ setLightTheme, lightTheme }: NavProps): ReactElement => {
   const [ isMobileMenuOpen, setIsMobileMenuOpen ] = useState(false);
 
   return <>
-    <div className="transition-all duration-500 bg-sea-white-100 dark:bg-sea-blue-500">
+    <div
+      className="transition-all duration-500 bg-sea-white-100 dark:bg-sea-blue-500"
+      data-cy="nav-container"
+    >
       <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8">
         <div className="relative flex items-center justify-between h-16">
           <MobileMenuButton
@@ -48,13 +51,14 @@ export const Nav = ({ setLightTheme, lightTheme }: NavProps): ReactElement => {
               </div>
             </div>
             <div className="hidden sm:block sm:ml-6">
-              <div className="flex space-x-4">
+              <div className="flex space-x-4" data-cy="nav-links">
                 {navButtons.map((button, index) => (
                   <a
                     key={index}
                     href={button.href}
                     className={conditionalButtonClasses(button)}
                     aria-current={button.current ? 'page' : undefined}
+                    data-cy={`nav-link-${button.name}`}
                   >
                     {button.name}
                   </a>
@@ -68,13 +72,17 @@ export const Nav = ({ setLightTheme, lightTheme }: NavProps): ReactElement => {
             </div>
             <button
               type="button"
+              data-cy="nav-notification"
               className="p-1 text-sea-blue-300 focus:text-sea-blue-500 flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-sea-blue-500 focus:ring-sea-white-100 dark:bg-sea-blue-500 dark:text-sea-white-300 dark:focus:text-sea-white-100 transition-all duration-300"
             >
               <span className="sr-only">View notifications</span>
               <Bell className="h-6 w-6" aria-hidden="true" />
             </button>
             <div className="ml-3 relative">
-              <button className="flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-sea-blue-500 focus:ring-sea-white-100 dark:bg-sea-blue-500 transition-all duration-300">
+              <button
+                data-cy="nav-user-profile"
+                className="flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-sea-blue-500 focus:ring-sea-white-100 dark:bg-sea-blue-500 transition-all duration-300"
+              >
                 <span className="sr-only">Open user menu</span>
                 <div className="h-8 w-8 rounded-full">
                   <Image

--- a/components/ToggleTheme.tsx
+++ b/components/ToggleTheme.tsx
@@ -19,6 +19,7 @@ export const ToggleTheme = ({
     />
     <label
       htmlFor="toggle-theme"
+      data-cy="nav-toggle-theme"
       className="w-10 h-6 rounded-full border-2 border-solid peer-checked:border-sea-sky-800 flex relative transition-all duration-1000 peer-checked:bg-sea-sky-400 bg-sea-foam-blue-400 border-sea-foam-blue-700
         peer-checked:before:animate-toggleTheme peer-checked:before:transition-all before:animate-toggleThemeReverse before:transition-all before:content-[''] before:w-5 before:h-5 before:border-2 before:border-solid peer-checked:before:border-yellow-400 peer-checked:before:bg-yellow-200 before:border-sea-white-300 before:bg-sea-white-100 peer-checked:before:left-0 before:left-4 before:relative before:rounded-full cursor-pointer"
     >

--- a/cypress/e2e/Nav/desktop.cy.ts
+++ b/cypress/e2e/Nav/desktop.cy.ts
@@ -1,8 +1,72 @@
+import { hexToRgb } from '../../helpers';
+
 describe('desktop navbar', () => {
-  it('should have the full seabuggy logo', () => {
-    cy.visit('http://localhost:3000/');
-    cy.viewport('macbook-16');
-    cy.get('[data-cy="dark-full-logo"]').should('have.attr', 'alt', 'Dark Seabuggy logo').should('be.be.visible');
+  describe('common elements', () => {
+    it('contains navigation links', () => {
+      cy.visit('http://localhost:3000/');
+      cy.viewport('macbook-16');
+      cy.get('[data-cy="nav-links"]').should('be.visible');
+    });
+
+    it('contains toggle to change the theme from light to dark', () => {
+      cy.get('[data-cy="nav-toggle-theme"]').should('be.visible');
+    });
+
+    it('contains the notifications button', () => {
+      cy.get('[data-cy="nav-notification"]').should('be.visible');
+    });
+
+    it('contains the user profile button', () => {
+      cy.get('[data-cy="nav-user-profile"]').should('be.visible');
+    });
+  });
+
+  describe('themes', () => {
+    describe('dark theme', () => {
+      it('should have the full seabuggy logo', () => {
+        cy.visit('http://localhost:3000/');
+        cy.viewport('macbook-16');
+        cy.get('[data-cy="dark-full-logo"]').should('have.attr', 'alt', 'Dark Seabuggy logo').should('be.visible');
+      });
+
+      it('has a dark background color', () => {
+        cy.get('[data-cy="nav-container"]').should('have.css', 'background-color', hexToRgb('232946'));
+      });
+
+      it('has the active color on the dashboard button', () => {
+        cy.get('[data-cy="nav-link-Dashboard"]').should('have.css', 'background-color', hexToRgb('15192A'));
+      });
+
+      it('has the toggle theme button styled for dark theme', () => {
+        cy.get('[data-cy="nav-toggle-theme"]').should('have.css', 'background-color', hexToRgb('a6aed4'))
+          .should('have.css', 'border-color', hexToRgb('767b97'));
+      });
+    });
+
+    describe('light theme', () => {
+      it('switches to light theme when using the toggle theme component', () => {
+        cy.visit('http://localhost:3000/');
+        cy.viewport('macbook-16');
+        cy.get('[data-cy="nav-toggle-theme"]').click();
+        cy.get('[data-cy="nav-container"]').should('have.css', 'background-color', hexToRgb('FFFFFE'));
+      });
+
+      it('should have the full seabuggy logo', () => {
+        cy.visit('http://localhost:3000/');
+        cy.viewport('macbook-16');
+        cy.get('[data-cy="nav-toggle-theme"]').click();
+        cy.get('[data-cy="light-full-logo"]').should('have.attr', 'alt', 'Light Seabuggy logo').should('be.visible');
+      });
+
+      it('has the active color on the dashboard button', () => {
+        cy.get('[data-cy="nav-link-Dashboard"]').should('have.css', 'background-color', hexToRgb('0065CB'));
+      });
+
+      it('has the toggle theme button styled for light theme', () => {
+        cy.get('[data-cy="nav-toggle-theme"]').should('have.css', 'background-color', hexToRgb('97D7E0'))
+          .should('have.css', 'border-color', hexToRgb('61949b'));
+      });
+    });
   });
 });
 

--- a/cypress/helpers/index.spec.ts
+++ b/cypress/helpers/index.spec.ts
@@ -1,0 +1,8 @@
+import { expect } from '@jest/globals';
+import { hexToRgb } from '.';
+
+describe('hexToRgb', () => {
+  it('converts a hex code to its rgb equivalent', () => {
+    expect(hexToRgb('FFFFFF')).toEqual('rgb(255, 255, 255)');
+  });
+});

--- a/cypress/helpers/index.ts
+++ b/cypress/helpers/index.ts
@@ -1,0 +1,6 @@
+export const hexToRgb = (hex) => {
+  const rValue = parseInt(hex.substring(0, 2), 16);
+  const gValue = parseInt(hex.substring(2, 4), 16);
+  const bValue = parseInt(hex.substring(4), 16);
+  return `rgb(${rValue}, ${gValue}, ${bValue})`;
+};

--- a/cypress/helpers/index.ts
+++ b/cypress/helpers/index.ts
@@ -1,4 +1,4 @@
-export const hexToRgb = (hex) => {
+export const hexToRgb = (hex: string): string => {
   const rValue = parseInt(hex.substring(0, 2), 16);
   const gValue = parseInt(hex.substring(2, 4), 16);
   const bValue = parseInt(hex.substring(4), 16);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "tf-next": "tf-next build",
     "test": "jest --watch",
     "test:ci": "jest --ci",
-    "test:cypress": "npm run dev && cypress run"
+    "test:cypress": "cypress run",
+    "test:ci:cypress": "npm run dev && cypress run"
   },
   "dependencies": {
     "@hookform/error-message": "^2.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds Cypress tests for the Nav bar in desktop view.  It also adds more data tags to the elements within the Nav that we want to hook into, which is a Cypress best practice and will help for more automated suites later on.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to have automated acceptance tests as Seabuggy grows.  Because we have both the desktop and mobile views of Seabuggy, I've split these tests based on view port size.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cypress tests are passing and identifying key Nav elements.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.